### PR TITLE
Generate new walks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import './index.css'
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import Homepage from './presentation/view/Homepage/Homepage';
 import { WalkStatus } from './util/types/WalkTypes';
@@ -26,7 +25,7 @@ function App() {
   const updateWalkUseCase = new UpdateWalk(walkRepository);
 
   // View Layer
-  const homepageViewModel = new HomepageViewModel(getCurrentWalkUseCase, updateWalkUseCase);
+  const homepageViewModel = new HomepageViewModel(getCurrentWalkUseCase, updateWalkUseCase, generateWalkUseCase);
 
   return (
     <div>

--- a/src/data/DataSource/DB/WalkDBDataSourceImpl.ts
+++ b/src/data/DataSource/DB/WalkDBDataSourceImpl.ts
@@ -13,7 +13,7 @@ const localStorageFetch = (key: string): WalkDBEntity[] => {
 export default class WalkDBDataSourceImpl implements WalkDataSource {
     createWalk = (walk: Walk) => {
         let walks = localStorageFetch(WALKS_DATA_KEY);
-        const walkToAdd: WalkDBEntity = { id: walk.id, duration: walk.duration, elapsed: walk.elapsed, date: walk.date.toDateString(), status: walk.status }
+        const walkToAdd: WalkDBEntity = {...walk, date: walk.date.toDateString()}
         walks.push(walkToAdd);
         localStorage.setItem(WALKS_DATA_KEY, JSON.stringify(walks));
     };
@@ -33,7 +33,7 @@ export default class WalkDBDataSourceImpl implements WalkDataSource {
     };
     updateWalk = (walk: Walk) => {
         const walks = localStorageFetch(WALKS_DATA_KEY);
-        const updatedWalks = walks.map((walkData) => walkData.id === walk.id ? walk : walkData);
+        const updatedWalks = walks.map((walkData) => walkData.id === walk.id ? {...walk, date: walk.date.toDateString()} : walkData);
         localStorage.setItem(WALKS_DATA_KEY, JSON.stringify(updatedWalks));
     };
 }

--- a/src/domain/usecase/Walk/GenerateWalk.ts
+++ b/src/domain/usecase/Walk/GenerateWalk.ts
@@ -32,6 +32,7 @@ export default class GenerateWalk implements GenerateWalkUseCase {
     generateWalk = (previousWalk: Walk) => {
         const newDuration = Math.round(previousWalk.duration * 1.1);
         const newDate = new Date();
+        // Temporary method of user data access until it is properly implemented
         const walkDays = localStorage.getItem("days");
         let walkDaysArr: number[];
         if (walkDays === null) {

--- a/src/domain/usecase/Walk/GenerateWalk.ts
+++ b/src/domain/usecase/Walk/GenerateWalk.ts
@@ -14,10 +14,35 @@ export default class GenerateWalk implements GenerateWalkUseCase {
         this.walkRepository = walkRepository;
     }
 
+    findNextWalkDay = (currentDay: number, walkDays: number[]): number => {
+        walkDays = walkDays.sort();
+        const currentDayIdx = walkDays.findIndex((day) => day === currentDay);
+        const newDayIdx = (currentDayIdx + 1) % walkDays.length;
+        return newDayIdx;
+    }
+
+    findNextWalkDate = (walkDay: number): Date => {
+        let walkDate = new Date();
+        // Get next date of walkDay
+        // Eg. if walkDay = 1 (monday), find the date of the next monday
+        walkDate.setDate(walkDate.getDate() + (walkDay - 1 - walkDate.getDay() + 7) % 7 + 1);
+        return walkDate;
+    }
+
     generateWalk = (previousWalk: Walk) => {
-        const newDuration = 1;
+        const newDuration = Math.round(previousWalk.duration * 1.1);
         const newDate = new Date();
-        const newWalk = new Walk(crypto.randomUUID(), newDuration, 0, newDate, PENDING_STATUS)
+        const walkDays = localStorage.getItem("days");
+        let walkDaysArr: number[];
+        if (walkDays === null) {
+            walkDaysArr = [];
+        }
+        else {
+            walkDaysArr = JSON.parse(walkDays);
+        }
+        const nextWalkDayIdx = this.findNextWalkDay(newDate.getDay(), walkDaysArr);
+        const nextWalkDate = this.findNextWalkDate(walkDaysArr[nextWalkDayIdx]);
+        const newWalk = new Walk(crypto.randomUUID(), newDuration, 0, nextWalkDate, PENDING_STATUS);
         this.walkRepository.createWalk(newWalk);
     }
 }

--- a/src/presentation/view/Homepage/Homepage.tsx
+++ b/src/presentation/view/Homepage/Homepage.tsx
@@ -52,7 +52,6 @@ const Homepage = ({ homepageViewModel }: HomepageProps) => {
                     <p>You're done for today.</p>
                 </div>
             }
-            <button onClick={() => homepageViewModel.generateWalk()}>New walk</button>
         </div>
     )
 }

--- a/src/presentation/view/Homepage/Homepage.tsx
+++ b/src/presentation/view/Homepage/Homepage.tsx
@@ -52,6 +52,7 @@ const Homepage = ({ homepageViewModel }: HomepageProps) => {
                     <p>You're done for today.</p>
                 </div>
             }
+            <button onClick={() => homepageViewModel.generateWalk()}>New walk</button>
         </div>
     )
 }

--- a/src/presentation/view_model/HomepageViewModel.ts
+++ b/src/presentation/view_model/HomepageViewModel.ts
@@ -5,6 +5,7 @@ import { action, makeAutoObservable, makeObservable, observable } from "mobx";
 import { UpdateWalkUseCase } from "../../domain/usecase/Walk/UpdateWalk";
 import { WalkStatus } from "../../util/types/WalkTypes";
 import { COMPLETED_STATUS } from "../../util/generalVals";
+import { GenerateWalkUseCase } from "../../domain/usecase/Walk/GenerateWalk";
 
 export class HomepageViewModel {
     // Track current walk as it updates
@@ -12,11 +13,13 @@ export class HomepageViewModel {
     isPaused: boolean = true;
     getCurrentWalkUseCase: GetCurrentWalkUseCase;
     updateWalkUseCase: UpdateWalkUseCase;
+    generateWalkUseCase: GenerateWalkUseCase;
 
     // Link relevant use case for getting the current walk
-    constructor(getCurrentWalkUseCase: GetCurrentWalkUseCase, updateWalkUseCase: UpdateWalkUseCase) {
+    constructor(getCurrentWalkUseCase: GetCurrentWalkUseCase, updateWalkUseCase: UpdateWalkUseCase, generateWalkUseCase: GenerateWalkUseCase) {
         this.getCurrentWalkUseCase = getCurrentWalkUseCase;
         this.updateWalkUseCase = updateWalkUseCase;
+        this.generateWalkUseCase = generateWalkUseCase;
         makeAutoObservable(this);
     }
 
@@ -60,5 +63,11 @@ export class HomepageViewModel {
     // Pause and unpause the timer
     togglePause = (): void => {
         this.isPaused = !this.isPaused;
+    }
+
+    generateWalk = (): void => {
+        if (this.currentWalk !== undefined) {
+            this.generateWalkUseCase.generateWalk(this.currentWalk);
+        }
     }
 }

--- a/src/presentation/view_model/HomepageViewModel.ts
+++ b/src/presentation/view_model/HomepageViewModel.ts
@@ -41,9 +41,10 @@ export class HomepageViewModel {
     elapseTime = (seconds: number): void => {
         if (this.currentWalk !== undefined) {
             const updatedWalk: Walk = {...this.currentWalk, elapsed: this.currentWalk.elapsed + seconds};
-            // If elapsing time finished the walk, update the status
+            // If elapsing time finished the walk, complete the walk and generate the next one
             if (updatedWalk.elapsed === updatedWalk.duration) {
                 updatedWalk.status = COMPLETED_STATUS;
+                this.generateWalkUseCase.generateWalk(this.currentWalk);
             }
             this.currentWalk = updatedWalk;
             this.updateWalkUseCase.updateWalk(updatedWalk);

--- a/src/util/generalVals.ts
+++ b/src/util/generalVals.ts
@@ -1,3 +1,4 @@
 export const IN_PROGRESS_STATUS = "IN_PROGRESS"
 export const PENDING_STATUS = "PENDING"
 export const COMPLETED_STATUS = "COMPLETED"
+export const DAYS_OF_THE_WEEK = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]


### PR DESCRIPTION
### Summary
This PR adds the function of generating a new walk, and triggers this functionality when a walk is completed.

### Description
Generating a new walk involves some business logic in the domain layer, found in the GenerateWalk use case. This involves:
- Determining the duration of the new walk, which is the duration of the current walk increased by x% (where x is the percentage increase the user has specified)
- Determining the date of the next walk - the user has chosen their walk days (eg. Mon, Wed, Fri) and so the next walk must be on their next chosen day (eg. if they have just finished a walk on Wed, the date for the next walk should be the date of the soonest Friday).

Once these things are determined, a new walk is created using them with the pending status and is saved to the database (local storage) using the data layer.

When a user finishes a walk, the next walk is generated.

### Future improvements
As creating a user and storing their preferences has not yet been implemented, a temporary method of accessing the user's walk days has been used which will be refactored once proper preference storage has been set up. For now, walks always increase by 10% and not by the user's specified value for the same reason, which will also be fixed once users are properly set up.